### PR TITLE
Add feature to export inventory data to PDF and Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ curl http://127.0.0.1:5000/books/search?query=Gatsby
 curl http://127.0.0.1:5000/books/summary
 ```
 
+### Export Books to PDF
+```sh
+curl http://127.0.0.1:5000/books/export/pdf
+```
+
+### Export Books to Excel
+```sh
+curl http://127.0.0.1:5000/books/export/excel
+```
+
 ## Code Comments
 
 The code includes comments for clarity. Please refer to the `book_store.py` and `test_book_store.py` files for detailed explanations of each function and class.

--- a/book_store.py
+++ b/book_store.py
@@ -1,6 +1,8 @@
 import json
 import os
 from flask import Flask, request, jsonify
+from fpdf import FPDF
+import pandas as pd
 
 class Book:
     def __init__(self, title, author, price, quantity):
@@ -62,6 +64,18 @@ class BookStore:
             'total_inventory_value': total_inventory_value
         }
 
+    def export_books_to_pdf(self):
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        for book in self.books:
+            pdf.cell(200, 10, txt=f"Title: {book['title']}, Author: {book['author']}, Price: {book['price']}, Quantity: {book['quantity']}", ln=True)
+        pdf.output("books.pdf")
+
+    def export_books_to_excel(self):
+        df = pd.DataFrame(self.books)
+        df.to_excel("books.xlsx", index=False)
+
 app = Flask(__name__)
 store = BookStore()
 
@@ -100,6 +114,16 @@ def search_books():
 def get_summary_statistics():
     stats = store.get_summary_statistics()
     return jsonify(stats), 200
+
+@app.route('/books/export/pdf', methods=['GET'])
+def export_books_to_pdf():
+    store.export_books_to_pdf()
+    return jsonify({'message': 'Books exported to PDF successfully!'}), 200
+
+@app.route('/books/export/excel', methods=['GET'])
+def export_books_to_excel():
+    store.export_books_to_excel()
+    return jsonify({'message': 'Books exported to Excel successfully!'}), 200
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/test_book_store.py
+++ b/test_book_store.py
@@ -84,5 +84,23 @@ class TestBookStore(unittest.TestCase):
         self.assertEqual(stats['total_books'], 2)
         self.assertEqual(stats['total_inventory_value'], 10.99 * 5 + 12.99 * 3)
 
+    def test_export_books_to_pdf(self):
+        book1 = Book('Test Title 1', 'Test Author 1', 10.99, 5)
+        book2 = Book('Test Title 2', 'Test Author 2', 12.99, 3)
+        self.store.add_book(book1)
+        self.store.add_book(book2)
+        response = self.app.get('/books/export/pdf')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(os.path.exists('books.pdf'))
+
+    def test_export_books_to_excel(self):
+        book1 = Book('Test Title 1', 'Test Author 1', 10.99, 5)
+        book2 = Book('Test Title 2', 'Test Author 2', 12.99, 3)
+        self.store.add_book(book1)
+        self.store.add_book(book2)
+        response = self.app.get('/books/export/excel')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(os.path.exists('books.xlsx'))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Related to #4

Add feature to export inventory data to PDF and Excel.

* **book_store.py**
  - Import `FPDF` and `pandas` libraries.
  - Add `export_books_to_pdf` method to export inventory data to PDF.
  - Add `export_books_to_excel` method to export inventory data to Excel.
  - Add routes `/books/export/pdf` and `/books/export/excel` to handle export requests.

* **README.md**
  - Add instructions on how to use the export feature.

* **test_book_store.py**
  - Add tests for `export_books_to_pdf` method.
  - Add tests for `export_books_to_excel` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/siddjoshi/book-store-demo/pull/5?shareId=2d818f54-8c74-455c-92e1-f4b8752c9848).